### PR TITLE
Respect receipt time during verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The library provides functions and classes to do the following.
 To install `iap_local_receipt` you need:
 
 * Python 2.5 or later in the 2.x line (earlier than 2.5 not tested).
-* `swig` and the gcc compiler to compile `M2Crypto`.
 
 If you have the dependencies, you have multiple options for installation:
 

--- a/iap_local_receipt/iap_pkcs7_verifier.py
+++ b/iap_local_receipt/iap_pkcs7_verifier.py
@@ -24,7 +24,7 @@ class PKCS7Verifier:
         """
         Load a CA cert from a PEM file, replacing any previous cert.
         """
-        self.load_ca_cert_string(open(ca_cert_file, 'r').read())
+        self.load_ca_cert_string(open(ca_cert_file, 'rb').read())
 
     def load_ca_cert_string(self, ca_cert_string):
         """
@@ -44,7 +44,7 @@ class PKCS7Verifier:
         Throw PKCS7VerifyError if verification failed.
         This will fail if the CA cert has not been loaded.
         """
-        return self.verify_data(open(pkcs7_der_file, 'r').read(), verify_time)
+        return self.verify_data(open(pkcs7_der_file, 'rb').read(), verify_time)
 
     def verify_data(self, pkcs7_der, verify_time=None):
         """

--- a/iap_local_receipt/iap_pkcs7_verifier.py
+++ b/iap_local_receipt/iap_pkcs7_verifier.py
@@ -82,5 +82,5 @@ def load_pkcs7_bio_der(p7_der):
     """
     try:
         return crypto.load_pkcs7_data(crypto.FILETYPE_ASN1, p7_der)
-    except:
-        raise PKCS7VerifyError(crypto._lib.ERR_get_error())
+    except crypto.Error as ex:
+        raise PKCS7VerifyError(ex)

--- a/iap_local_receipt/iap_receipt_parser.py
+++ b/iap_local_receipt/iap_receipt_parser.py
@@ -14,6 +14,7 @@ FT_BUNDLE_ID = 2
 FT_APPLICATION_VERSION = 3
 FT_OPAQUE_VALUE = 4
 FT_SHA1_HASH = 5
+FT_RECEIPT_CREATION_DATE = 12
 FT_IN_APP = 17
 FT_ORIGINAL_APPLICATION_VERSION = 19
 FT_EXPIRATION_DATE = 21
@@ -85,6 +86,7 @@ RCPT_FIELD_MAP = {
     FT_APPLICATION_VERSION:          (lambda x: octets_to_utf8(x)),
     FT_OPAQUE_VALUE:                 (lambda x: x.asOctets()),
     FT_SHA1_HASH:                    (lambda x: x.asOctets()),
+    FT_RECEIPT_CREATION_DATE:        (lambda x: ia5_to_datetime(x)),
     FT_ORIGINAL_APPLICATION_VERSION: (lambda x: octets_to_utf8(x)),
     FT_EXPIRATION_DATE:              (lambda x: ia5_to_datetime(x)),
 }
@@ -113,6 +115,7 @@ class AppReceiptFieldType(univ.Integer):
         ('opaque_value',                 FT_OPAQUE_VALUE),
         ('sha1_hash',                    FT_SHA1_HASH),
         ('in_app',                       FT_IN_APP),
+        ('receipt_creation_date',        FT_RECEIPT_CREATION_DATE),
         ('original_application_version', FT_ORIGINAL_APPLICATION_VERSION),
         ('expiration_date',              FT_EXPIRATION_DATE)
     )
@@ -124,7 +127,7 @@ class AppReceiptField(univ.Sequence):
         namedtype.NamedType('type',    AppReceiptFieldType()),
         namedtype.NamedType('version', rfc2315.Version()),
         namedtype.NamedType('value',   univ.OctetString())
-        )
+    )
 
 
 class AppReceipt(univ.SetOf):

--- a/iap_local_receipt/iap_receipt_parser.py
+++ b/iap_local_receipt/iap_receipt_parser.py
@@ -2,7 +2,7 @@ from pyasn1_modules import rfc2315
 from pyasn1.codec.der import decoder
 from pyasn1.type import namedtype, namedval, univ, char
 
-import rfc3339
+from . import rfc3339
 
 from .iap_receipt import IAPReceipt
 

--- a/iap_local_receipt/iap_receipt_verifier.py
+++ b/iap_local_receipt/iap_receipt_verifier.py
@@ -24,10 +24,12 @@ class IAPReceiptVerifier(object):
         signed data (the actual receipt ASN.1 data).
         Return IAPReceipt.
         """
-        receipt_der = self.verify_signature(pkcs7_der)
+        receipt_der = self._verifier.get_data_without_certificate_verification(pkcs7_der)
+        receipt = self.parse(receipt_der)
+        receipt_der = self.verify_signature(pkcs7_der, receipt_time=receipt.receipt['receipt_creation_date'])
         return self.parse(receipt_der)
 
-    def verify_signature(self, pkcs7_der):
+    def verify_signature(self, pkcs7_der, receipt_time=None):
         """
         Extract the PKCS7 container from the DER binary.
         Verify the receipt signature against Apple's Root CA cert,
@@ -35,7 +37,7 @@ class IAPReceiptVerifier(object):
         data.
         Return the raw receipt blob in ASN.1 format.
         """
-        return self._verifier.verify_data(pkcs7_der)
+        return self._verifier.verify_data(pkcs7_der, receipt_time)
 
     def parse(self, receipt_der):
         """

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "pyasn1",
         "pyasn1_modules",
-        "pyopenssl>=16.3.0",
+        "pyopenssl>=17.0.0",
     ],
     license="BSD",
     classifiers=classifiers,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ classifiers = [
 
 setup(
     name="iap_local_receipt",
-    version="0.1.0",
+    version="0.2.0",
     author="Edwin Fine",
     author_email="me@edfine.io",
     url="https://github.com/SilentCircle/iap-local-receipt",
@@ -25,8 +25,8 @@ setup(
     install_requires=[
         "pyasn1",
         "pyasn1_modules",
-        "m2crypto",
-        ],
+        "pyopenssl",
+    ],
     license="BSD",
     classifiers=classifiers,
     packages=["iap_local_receipt"],

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "pyasn1",
         "pyasn1_modules",
-        "pyopenssl",
+        "pyopenssl>=16.3.0",
     ],
     license="BSD",
     classifiers=classifiers,


### PR DESCRIPTION
Certificates should be verified at the time of signature, which is indicated by the Receipt Creation Date (field type 12).

See Apple documentation:
> Note: Many cryptographic libraries default to using the device’s current time and date when validating a pkcs7 package, but this may not produce the correct results when validating a receipt’s signature. For example, if the receipt was signed with a valid certificate, but the certificate has since expired, using the device’s current date incorrectly returns an invalid result.
> Therefore, make sure your app always uses the date from the Receipt Creation Date field to validate the receipt’s signature.

For this, I'm switching from m2 to the more-common pyopenssl.